### PR TITLE
nextdns.rb: delete 'bottle :unneeded'

### DIFF
--- a/nextdns.rb
+++ b/nextdns.rb
@@ -6,7 +6,6 @@ class Nextdns < Formula
   desc "NextDNS DNS/53 to DoH Proxy"
   homepage "https://nextdns.io"
   version "1.37.7"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Fixes #6

For a few months now, every invocation of `brew` has been showing this warning on the console:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the nextdns/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/nextdns/homebrew-tap/nextdns.rb:9
```

This PR makes this warning disappear by deleting from the formula the entry that has been deprecated without a replacement.